### PR TITLE
Run tests in PHP 7.0 and HHVM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
+  - hhvm
+
+matrix:
+  allow_failures:
+    - php: hhvm
+    - php: 7.0
 
 services:
   - apc


### PR DESCRIPTION
- Allow PHP 7 and HHVM tests to fail
- [ ] need to modify the phpenv config-add statements for PHP7 and HHVM