### PR TITLE
If browser match fails we should set state as error like in IP Matching

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -694,8 +694,9 @@ class Session implements SessionInterface, DispatcherAwareInterface
 			}
 			elseif ($_SERVER['HTTP_USER_AGENT'] !== $browser)
 			{
-				// @todo remove code: 				$this->_state	=	'error';
-				// @todo remove code: 				return false;
+				$this->setState('error');
+
+				return false;
 			}
 		}
 


### PR DESCRIPTION
When the IP Match fails a line above we set a status of error and return false in the function. This PR does the same thing if the browser check fails