### PR TITLE
Require Input for accessing $_SERVER variables

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "require": {
         "php": ">=5.4",
         "joomla/event": "2.0.*@dev",
-		"joomla/input": "2.0.*@dev"
+        "joomla/input": "2.0.*@dev"
     },
     "require-dev": {
         "joomla/database": "2.0.*@dev",

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
     "license": "GPL-2.0+",
     "require": {
         "php": ">=5.4",
-        "joomla/event": "2.0.*@dev"
+        "joomla/event": "2.0.*@dev",
+		"joomla/input": "2.0.*@dev"
     },
     "require-dev": {
         "joomla/database": "2.0.*@dev",

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -4,16 +4,20 @@ The Session package provides an interface for managing sessions within an applic
 within the package and serves as the primary API for managing a session.
 
 ### Creating your Session object
-The `Session` class constructor takes 3 optional parameters:
+The `Session` class constructor takes 1 compulsory and 3 optional parameters:
 
 ```php
 /**
+ * @param   Input                $input       The input object
  * @param   StorageInterface     $store       A StorageInterface implementation
  * @param   DispatcherInterface  $dispatcher  DispatcherInterface for the session to use.
  * @param   array                $options     Optional parameters
  */
 public function __construct(StorageInterface $store = null, DispatcherInterface $dispatcher = null, array $options = array())
 ```
+
+### Input Object
+The Joomla Input object - required for accessing some variables in `$_SERVER` when validating a session. For more information on the Input package please read the [Joomla Input Package Documentation](https://github.com/joomla-framework/input)
 
 #### Storage Object
 The `StorageInterface` defines an object which represents a data store for session data. For more about this please read the [StorageInterface documentation](classes/StorageInterface.md).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,7 +13,7 @@ The `Session` class constructor takes 1 compulsory and 3 optional parameters:
  * @param   DispatcherInterface  $dispatcher  DispatcherInterface for the session to use.
  * @param   array                $options     Optional parameters
  */
-public function __construct(StorageInterface $store = null, DispatcherInterface $dispatcher = null, array $options = array())
+public function __construct(Input $input, StorageInterface $store = null, DispatcherInterface $dispatcher = null, array $options = array())
 ```
 
 ### Input Object

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -38,8 +38,8 @@ container or the `Joomla\Application\AbstractWebApplication` object.
 
 ### Session::initialise() removed
 
-The `initialise` method has been removed. The base `Session` class no longer uses a `Joomla\Input\Input` object and the `Joomla\Event\DispatcherInterface`
-object should be injected via the constructor or the `setDispatcher` method.
+The `initialise` method has been removed. The base `Session` class now requires a `Joomla\Input\Input` object as part of the
+constructor and the `Joomla\Event\DispatcherInterface` object should be injected via the constructor or the `setDispatcher` method.
 
 ### Namespaced session variables dropped
 

--- a/src/Session.php
+++ b/src/Session.php
@@ -38,12 +38,12 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	protected $state = 'inactive';
 
 	/**
-	 * The input object.
+	 * The Input object.
 	 *
 	 * @var    Input
-	 * @since  __DEPLOY_VERSION__
+	 * @since  1.0
 	 */
-	protected $input;
+	private $input;
 
 	/**
 	 * Maximum age of unused session in minutes

--- a/src/Session.php
+++ b/src/Session.php
@@ -673,7 +673,7 @@ class Session implements SessionInterface, DispatcherAwareInterface
 		}
 
 		// Record proxy forwarded for in the session in case we need it later
-		$proxyForwarded = $this->input->server->get('HTTP_X_FORWARDED_FOR', null);
+		$proxyForwarded = $this->input->server->getString('HTTP_X_FORWARDED_FOR', null);
 
 		if ($proxyForwarded)
 		{
@@ -681,7 +681,7 @@ class Session implements SessionInterface, DispatcherAwareInterface
 		}
 
 		// Check for client address
-		$remoteServerAddress = $this->input->server->get('REMOTE_ADDR', null);
+		$remoteServerAddress = $this->input->server->getString('REMOTE_ADDR', null);
 
 		if (in_array('fix_address', $this->security) && $remoteServerAddress)
 		{
@@ -700,7 +700,7 @@ class Session implements SessionInterface, DispatcherAwareInterface
 		}
 
 		// Check for clients browser
-		$userAgent = $this->input->server->get('HTTP_USER_AGENT', null);
+		$userAgent = $this->input->server->getString('HTTP_USER_AGENT', null);
 
 		if (in_array('fix_browser', $this->security) && $userAgent)
 		{

--- a/src/Session.php
+++ b/src/Session.php
@@ -11,6 +11,7 @@ namespace Joomla\Session;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
+use Joomla\Input\Input;
 use Joomla\Session\Handler\FilesystemHandler;
 use Joomla\Session\Storage\NativeStorage;
 
@@ -35,6 +36,14 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	 * @since  1.0
 	 */
 	protected $state = 'inactive';
+
+	/**
+	 * The input object.
+	 *
+	 * @var    Input
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $input;
 
 	/**
 	 * Maximum age of unused session in minutes
@@ -68,13 +77,14 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	/**
 	 * Constructor
 	 *
+	 * @param   Input                $input       The input object
 	 * @param   StorageInterface     $store       A StorageInterface implementation
 	 * @param   DispatcherInterface  $dispatcher  DispatcherInterface for the session to use.
 	 * @param   array                $options     Optional parameters
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(StorageInterface $store = null, DispatcherInterface $dispatcher = null, array $options = array())
+	public function __construct(Input $input, StorageInterface $store = null, DispatcherInterface $dispatcher = null, array $options = array())
 	{
 		$this->store = $store ?: new NativeStorage(new FilesystemHandler);
 
@@ -82,6 +92,8 @@ class Session implements SessionInterface, DispatcherAwareInterface
 		{
 			$this->setDispatcher($dispatcher);
 		}
+
+		$this->input = $input;
 
 		$this->setOptions($options);
 
@@ -661,21 +673,25 @@ class Session implements SessionInterface, DispatcherAwareInterface
 		}
 
 		// Record proxy forwarded for in the session in case we need it later
-		if (isset($_SERVER['HTTP_X_FORWARDED_FOR']))
+		$proxyForwarded = $this->input->server->get('HTTP_X_FORWARDED_FOR', null);
+
+		if ($proxyForwarded)
 		{
-			$this->set('session.client.forwarded', $_SERVER['HTTP_X_FORWARDED_FOR']);
+			$this->set('session.client.forwarded', $proxyForwarded);
 		}
 
 		// Check for client address
-		if (in_array('fix_address', $this->security) && isset($_SERVER['REMOTE_ADDR']))
+		$remoteServerAddress = $this->input->server->get('REMOTE_ADDR', null);
+
+		if (in_array('fix_address', $this->security) && $remoteServerAddress)
 		{
 			$ip = $this->get('session.client.address');
 
 			if ($ip === null)
 			{
-				$this->set('session.client.address', $_SERVER['REMOTE_ADDR']);
+				$this->set('session.client.address', $remoteServerAddress);
 			}
-			elseif ($_SERVER['REMOTE_ADDR'] !== $ip)
+			elseif ($remoteServerAddress !== $ip)
 			{
 				$this->setState('error');
 
@@ -684,15 +700,17 @@ class Session implements SessionInterface, DispatcherAwareInterface
 		}
 
 		// Check for clients browser
-		if (in_array('fix_browser', $this->security) && isset($_SERVER['HTTP_USER_AGENT']))
+		$userAgent = $this->input->server->get('HTTP_USER_AGENT', null);
+
+		if (in_array('fix_browser', $this->security) && $userAgent)
 		{
 			$browser = $this->get('session.client.browser');
 
 			if ($browser === null)
 			{
-				$this->set('session.client.browser', $_SERVER['HTTP_USER_AGENT']);
+				$this->set('session.client.browser', $userAgent);
 			}
-			elseif ($_SERVER['HTTP_USER_AGENT'] !== $browser)
+			elseif ($userAgent !== $browser)
 			{
 				$this->setState('error');
 

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -34,16 +34,17 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 	 */
 	protected function setUp()
 	{
-		$this->storage = new MockStorage;
-		$mockInput     = $this->getMock('\\Joomla\\Input\\Input');
-				
+		$mockInput = $this->getMock('Joomla\Input\Input', array('get'));
+
 		// Mock the Input object internals
-		$mockServerInput = $this->getMock('Joomla\Input\Input', array('get', 'set'), array(), '', true, true, true, false, true);
+		$mockServerInput = $this->getMock('Joomla\Input\Input', array('get', 'set'));
 		$inputInternals = array(
 			'server' => $mockServerInput
 		);
+
 		TestHelper::setValue($mockInput, 'inputs', $inputInternals);
 
+		$this->storage = new MockStorage;
 		$this->session = new Session($mockInput, $this->storage);
 	}
 

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -8,6 +8,7 @@ namespace Joomla\Session\Tests;
 
 use Joomla\Session\Session;
 use Joomla\Session\Tests\Storage\MockStorage;
+use Joomla\Test\TestHelper;
 
 /**
  * Test class for Joomla\Session\Session.
@@ -34,7 +35,16 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 	protected function setUp()
 	{
 		$this->storage = new MockStorage;
-		$this->session = new Session($this->storage);
+		$mockInput     = $this->getMock('\\Joomla\\Input\\Input');
+				
+		// Mock the Input object internals
+		$mockServerInput = $this->getMock('Joomla\Input\Input', array('get', 'set'), array(), '', true, true, true, false, true);
+		$inputInternals = array(
+			'server' => $mockServerInput
+		);
+		TestHelper::setValue($mockInput, 'inputs', $inputInternals);
+
+		$this->session = new Session($mockInput, $this->storage);
 	}
 
 	/**
@@ -61,8 +71,9 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 	{
 		// Build a mock event dispatcher
 		$mockDispatcher = $this->getMock('\\Joomla\\Event\\DispatcherInterface');
+		$mockInput      = $this->getMock('\\Joomla\\Input\\Input');
 
-		$session = new Session($this->storage, $mockDispatcher);
+		$session = new Session($mockInput, $this->storage, $mockDispatcher);
 
 		// The state should be inactive
 		$this->assertSame('inactive', $session->getState());


### PR DESCRIPTION
This requires the Joomla Input package so we can access to the `$_SERVER` super global safely.

I think that `Input::getString` should provide adequate filtering of the variables without loosing any of the required data. Shout if otherwise!
