### PR TITLE
Lazy load the base Session object

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -346,6 +346,11 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	 */
 	public function get($name, $default = null)
 	{
+		if (!$this->isActive())
+		{
+			$this->start();
+		}
+
 		return $this->store->get($name, $default);
 	}
 
@@ -361,6 +366,11 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	 */
 	public function set($name, $value = null)
 	{
+		if (!$this->isActive())
+		{
+			$this->start();
+		}
+
 		return $this->store->set($name, $value);
 	}
 
@@ -375,6 +385,11 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	 */
 	public function has($name)
 	{
+		if (!$this->isActive())
+		{
+			$this->start();
+		}
+
 		return $this->store->has($name);
 	}
 
@@ -389,6 +404,11 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	 */
 	public function remove($name)
 	{
+		if (!$this->isActive())
+		{
+			$this->start();
+		}
+
 		return $this->store->remove($name);
 	}
 
@@ -401,6 +421,11 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	 */
 	public function clear()
 	{
+		if (!$this->isActive())
+		{
+			$this->start();
+		}
+
 		$this->store->clear();
 	}
 
@@ -413,6 +438,11 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	 */
 	public function all()
 	{
+		if (!$this->isActive())
+		{
+			$this->start();
+		}
+
 		return $this->store->all();
 	}
 

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -263,11 +263,8 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 		$this->session->set('foo', 'bar');
 		$this->session->set('joomla.framework', 'is awesome');
 
-		$this->assertSame(
-			array(
-				'foo' => 'bar',
-				'joomla.framework' => 'is awesome'
-			),
+		$this->assertArrayHasKey(
+			'joomla.framework',
 			$this->session->all()
 		);
 


### PR DESCRIPTION
Right now, the base Session class does not start itself when accessing data from the Storage object.  So calling `$session->get()` for example with the Session and Storage objects not started results in only the Storage starting itself.  This results in an inconsistent state between the Session and Storage objects.