### PR TITLE
Fix wrong expire usage

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -722,8 +722,8 @@ class Session implements SessionInterface, DispatcherAwareInterface
 			$this->security = explode(',', $options['security']);
 		}
 
-		// Sync the session maxlifetime
-		ini_set('session.gc_maxlifetime', $this->getExpire());
+		// Sync the session maxlifetime in seconds
+		ini_set('session.gc_maxlifetime', $this->getExpire() * 60);
 
 		return true;
 	}
@@ -760,7 +760,7 @@ class Session implements SessionInterface, DispatcherAwareInterface
 		if ($this->expire)
 		{
 			$curTime = $this->get('session.timer.now', 0);
-			$maxTime = $this->get('session.timer.last', 0) + $this->expire;
+			$maxTime = $this->get('session.timer.last', 0) + $this->expire * 60;
 
 			// Empty session variables
 			if ($maxTime < $curTime)


### PR DESCRIPTION
Expire is set in minutes but sometimes is used in seconds. Missing a ``* 60``