### PR TITLE
Session destroy causes that new session has `session.counter` = 2

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -571,7 +571,6 @@ class Session implements SessionInterface, DispatcherAwareInterface
 
 		if ($destroy)
 		{
-			$this->setCounter();
 			$this->setTimers();
 		}
 


### PR DESCRIPTION
When a session is destroyed the fork function is calling the `setCounter()` method that causes that new session starts with a `session.counter` = 2. So the `isNew()` method doesn't detect the new session as new.