### PR TITLE
Session cookies

### DIFF
--- a/Session.php
+++ b/Session.php
@@ -2,7 +2,7 @@
 /**
  * Part of the Joomla Framework Session Package
  *
- * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @copyright  Copyright (C) 2005 - 2016 Open Source Matters, Inc. All rights reserved.
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
@@ -601,7 +601,7 @@ class Session implements \IteratorAggregate
 				if ($session_clean)
 				{
 					session_id($session_clean);
-					$cookie->set($session_name, '', time() - 3600);
+					$cookie->set($session_name, '', 1);
 				}
 			}
 		}
@@ -649,7 +649,7 @@ class Session implements \IteratorAggregate
 		 */
 		if (isset($_COOKIE[session_name()]))
 		{
-			setcookie(session_name(), '', time() - 42000, $this->cookie_path, $this->cookie_domain);
+			$this->input->cookie(session_name(), '', 1);
 		}
 
 		session_unset();


### PR DESCRIPTION
Changes:
1. Use epoch + `1` to delete the cookie. I think it's not necessary `time() - xxxx`. Epoch + `1` should be enough. Also we can have problems with timezones if not putting time() less a full day.
2. Use the Api when deleting the cookie
3. Unless i'm missing something, we shouldn't need the `cookie_path` and the `cookie_domain` because is already set in `session_set_cookie_params`
4. Year 2015 to 2016

@mbabker please review if this is ok.
If ok, i will propose similar changes in the joomla rep.