### PR TITLE
Add session validation interface for custom session validation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "suggest": {
         "joomla/database": "Install joomla/database if you want to use Database session storage.",
         "joomla/event": "The joomla/event package is required to use Joomla\\Session\\Session.",
-        "joomla/input": "The joomla/input package is required to use Joomla\\Session\\Session.",
+        "joomla/input": "The joomla/input package is required to use Address and Forwarded session validators.",
         "paragonie/random_compat": "The paragonie/random_compat package is required to use Joomla\\Session\\Session on PHP 5.x.",
         "ext-apc": "To use APC cache as a session handler",
         "ext-apcu": "To use APCu cache as a session handler",

--- a/docs/classes/ValidatorInterface.md
+++ b/docs/classes/ValidatorInterface.md
@@ -1,0 +1,17 @@
+## ValidatorInterface
+
+The `ValidatorInterface` is designed to allow custom validation of the session to help protect against session attacks.
+
+### Check if the session is valid
+
+The `validate` method is used to check if the session is valid. If the session is invalid it should throw a
+`InvalidSessionException`. If the `$restart` flag is set to `true` then any data stored in the session should be
+invalidated (normally by setting it to `null`) and new properties retrieved.
+
+```php
+/*
+ * @return  void
+ */
+public function validate($restart = false);
+```
+

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -51,3 +51,10 @@ a top level container, such as `$_SESSION[$namespace]`. In v2, data is stored di
 In v1, when the `onAfterSessionStart` method was dispatched, a generic `Joomla\Event\Event` object was passed with no parameters. In v2,
 a `SessionEvent` object has been added and is dispatched with the `onAfterSessionStart` and new `onAfterSessionRestart` events. The `SessionEvent`
 object is dispatched with the current `Session` instance attached so its API is accessible within the events.
+
+### Session Validation Abstracted
+
+In order to allow the session package to be more easily integrated with other providers we have abstracted the session
+validators. A new interface, [ValidatorInterface](classes/ValidatorInterface.md) has been added to make it easier to add
+custom session validators as well as removing the hard dependency of the JInput class from the session package. This
+makes it easier when integrating the session package with PSR-7 compliant applications.

--- a/src/Exception/InvalidSessionException.php
+++ b/src/Exception/InvalidSessionException.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Part of the Joomla Framework Session Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Session\Exception;
+
+/**
+ * Exception thrown when a session validator fails
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class InvalidSessionException extends \RuntimeException
+{
+}

--- a/src/Session.php
+++ b/src/Session.php
@@ -11,7 +11,7 @@ namespace Joomla\Session;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
-use Joomla\Input\Input;
+use Joomla\Session\Exception\InvalidSessionException;
 use Joomla\Session\Handler\FilesystemHandler;
 use Joomla\Session\Storage\NativeStorage;
 
@@ -38,14 +38,6 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	protected $state = 'inactive';
 
 	/**
-	 * The Input object.
-	 *
-	 * @var    Input
-	 * @since  1.0
-	 */
-	private $input;
-
-	/**
 	 * Maximum age of unused session in seconds
 	 *
 	 * @var    integer
@@ -62,29 +54,23 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	protected $store;
 
 	/**
-	 * Security policy.
-	 * List of checks that will be done.
+	 * The session store object.
 	 *
-	 * Possible values:
-	 * - fix_browser
-	 * - fix_address
-	 *
-	 * @var    array
-	 * @since  1.0
+	 * @var    ValidatorInterface[]
+	 * @since  __DEPLOY_VERSION__
 	 */
-	protected $security = array('fix_browser');
+	protected $sessionValidators = array();
 
 	/**
 	 * Constructor
 	 *
-	 * @param   Input                $input       The input object
 	 * @param   StorageInterface     $store       A StorageInterface implementation
 	 * @param   DispatcherInterface  $dispatcher  DispatcherInterface for the session to use.
 	 * @param   array                $options     Optional parameters
 	 *
 	 * @since   1.0
 	 */
-	public function __construct(Input $input, StorageInterface $store = null, DispatcherInterface $dispatcher = null, array $options = array())
+	public function __construct(StorageInterface $store = null, DispatcherInterface $dispatcher = null, array $options = array())
 	{
 		$this->store = $store ?: new NativeStorage(new FilesystemHandler);
 
@@ -93,11 +79,23 @@ class Session implements SessionInterface, DispatcherAwareInterface
 			$this->setDispatcher($dispatcher);
 		}
 
-		$this->input = $input;
-
 		$this->setOptions($options);
 
 		$this->setState('inactive');
+	}
+
+	/**
+	 * Adds a validator to the session
+	 *
+	 * @param   ValidatorInterface  $validator  The session validator
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function addValidator(ValidatorInterface $validator)
+	{
+		$this->sessionValidators[] = $validator;
 	}
 
 	/**
@@ -715,12 +713,6 @@ class Session implements SessionInterface, DispatcherAwareInterface
 			$this->setExpire($options['expire']);
 		}
 
-		// Get security options
-		if (isset($options['security']))
-		{
-			$this->security = explode(',', $options['security']);
-		}
-
 		// Sync the session maxlifetime
 		ini_set('session.gc_maxlifetime', $this->getExpire());
 
@@ -728,13 +720,9 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	}
 
 	/**
-	 * Do some checks for security reason
+	 * Do some checks for security reasons
 	 *
-	 * - timeout check (expire)
-	 * - ip-fixiation
-	 * - browser-fixiation
-	 *
-	 * If one check failed, session data has to be cleaned.
+	 * If one check fails, session data has to be cleaned.
 	 *
 	 * @param   boolean  $restart  Reactivate session
 	 *
@@ -749,9 +737,6 @@ class Session implements SessionInterface, DispatcherAwareInterface
 		if ($restart)
 		{
 			$this->setState('active');
-
-			$this->set('session.client.address', null);
-			$this->set('session.client.forwarded', null);
 		}
 
 		// Check if session has expired
@@ -769,31 +754,18 @@ class Session implements SessionInterface, DispatcherAwareInterface
 			}
 		}
 
-		$remoteAddr = $this->input->server->getString('REMOTE_ADDR', '');
-
-		// Check for client address
-		if (in_array('fix_address', $this->security) && !empty($remoteAddr) && filter_var($remoteAddr, FILTER_VALIDATE_IP) !== false)
+		try
 		{
-			$ip = $this->get('session.client.address');
-
-			if ($ip === null)
+			foreach ($this->sessionValidators as $validator)
 			{
-				$this->set('session.client.address', $remoteAddr);
-			}
-			elseif ($remoteAddr !== $ip)
-			{
-				$this->setState('error');
-
-				return false;
+				$validator->validate($restart);
 			}
 		}
-
-		$xForwardedFor = $this->input->server->getString('HTTP_X_FORWARDED_FOR', '');
-
-		// Record proxy forwarded for in the session in case we need it later
-		if (!empty($xForwardedFor) && filter_var($xForwardedFor, FILTER_VALIDATE_IP) !== false)
+		catch (InvalidSessionException $e)
 		{
-			$this->set('session.client.forwarded', $xForwardedFor);
+			$this->setState('error');
+
+			return false;
 		}
 
 		return true;

--- a/src/Validator/AddressValidator.php
+++ b/src/Validator/AddressValidator.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Part of the Joomla Framework Session Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Session\Validator;
+
+use Joomla\Input\Input;
+use Joomla\Session\Exception\InvalidSessionException;
+use Joomla\Session\SessionInterface;
+use Joomla\Session\ValidatorInterface;
+
+/**
+ * Interface for validating a part of the session
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class AddressValidator implements ValidatorInterface
+{
+	/**
+	 * The Input object.
+	 *
+	 * @var    Input
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $input;
+
+	/**
+	 * The session object.
+	 *
+	 * @var    SessionInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $session;
+
+	/**
+	 * Constructor
+	 *
+	 * @param   Input             $input    The input object
+	 * @param   SessionInterface  $session  DispatcherInterface for the session to use.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(Input $input, SessionInterface $session)
+	{
+		$this->input   = $input;
+		$this->session = $session;
+	}
+
+	/**
+	 * Validates the session throwing a SessionValidationException if there is an invalid property in the exception
+	 *
+	 * @param   boolean  $restart  Reactivate session
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  InvalidSessionException
+	 */
+	public function validate($restart = false)
+	{
+		if ($restart)
+		{
+			$this->session->set('session.client.address', null);
+		}
+
+		$remoteAddr = $this->input->server->getString('REMOTE_ADDR', '');
+
+		// Check for client address
+		if (!empty($remoteAddr) && filter_var($remoteAddr, FILTER_VALIDATE_IP) !== false)
+		{
+			$ip = $this->session->get('session.client.address');
+
+			if ($ip === null)
+			{
+				$this->session->set('session.client.address', $remoteAddr);
+			}
+			elseif ($remoteAddr !== $ip)
+			{
+				throw new InvalidSessionException('Invalid client IP');
+			}
+		}
+	}
+}

--- a/src/Validator/ForwardedValidator.php
+++ b/src/Validator/ForwardedValidator.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Part of the Joomla Framework Session Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Session\Validator;
+
+use Joomla\Input\Input;
+use Joomla\Session\SessionInterface;
+use Joomla\Session\ValidatorInterface;
+
+/**
+ * Interface for validating a part of the session
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ForwardedValidator implements ValidatorInterface
+{
+	/**
+	 * The Input object.
+	 *
+	 * @var    Input
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $input;
+
+	/**
+	 * The session object.
+	 *
+	 * @var    SessionInterface
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $session;
+
+	/**
+	 * Constructor
+	 *
+	 * @param   Input             $input    The input object
+	 * @param   SessionInterface  $session  DispatcherInterface for the session to use.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(Input $input, SessionInterface $session)
+	{
+		$this->input   = $input;
+		$this->session = $session;
+	}
+
+	/**
+	 * Validates the session throwing a SessionValidationException if there is an invalid property in the exception
+	 *
+	 * @param   boolean  $restart  Reactivate session
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function validate($restart = false)
+	{
+		if ($restart)
+		{
+			$this->session->set('session.client.forwarded', null);
+		}
+
+		$xForwardedFor = $this->input->server->getString('HTTP_X_FORWARDED_FOR', '');
+
+		// Record proxy forwarded for in the session in case we need it later
+		if (!empty($xForwardedFor) && filter_var($xForwardedFor, FILTER_VALIDATE_IP) !== false)
+		{
+			$this->session->set('session.client.forwarded', $xForwardedFor);
+		}
+	}
+}

--- a/src/ValidatorInterface.php
+++ b/src/ValidatorInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Part of the Joomla Framework Session Package
+ *
+ * @copyright  Copyright (C) 2005 - 2015 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\Session;
+
+use Joomla\Session\Exception\InvalidSessionException;
+
+/**
+ * Interface for validating a part of the session
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface ValidatorInterface
+{
+	/**
+	 * Validates the session throwing a SessionValidationException if there is an invalid property in the exception
+	 *
+	 * @param   boolean  $restart  Reactivate session
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @throws  InvalidSessionException
+	 */
+	public function validate($restart = false);
+}

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -8,6 +8,8 @@ namespace Joomla\Session\Tests;
 
 use Joomla\Session\Session;
 use Joomla\Session\Tests\Storage\MockStorage;
+use Joomla\Session\Validator\AddressValidator;
+use Joomla\Session\Validator\ForwardedValidator;
 use Joomla\Test\TestHelper;
 
 /**
@@ -45,7 +47,11 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 		TestHelper::setValue($mockInput, 'inputs', $inputInternals);
 
 		$this->storage = new MockStorage;
-		$this->session = new Session($mockInput, $this->storage);
+		$this->session = new Session($this->storage);
+		$addressValidator = new AddressValidator($mockInput, $this->session);
+		$forwardedValidator = new ForwardedValidator($mockInput, $this->session);
+		$this->session->addValidator($addressValidator);
+		$this->session->addValidator($forwardedValidator);
 	}
 
 	/**
@@ -72,9 +78,8 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 	{
 		// Build a mock event dispatcher
 		$mockDispatcher = $this->getMock('\\Joomla\\Event\\DispatcherInterface');
-		$mockInput      = $this->getMock('\\Joomla\\Input\\Input');
 
-		$session = new Session($mockInput, $this->storage, $mockDispatcher);
+		$session = new Session($this->storage, $mockDispatcher);
 
 		// The state should be inactive
 		$this->assertSame('inactive', $session->getState());


### PR DESCRIPTION
This adds a custom session validation interface with two example session validators (the two current validators). This removes the hard dependency we have on the `Input` package in the session and means that you can now use this package with PSR-7 compatible packages by building your own custom validators.

It also means that if you want to you can remove setting this data in the session or simply build your own validators without extending the class and overriding the validate method (yay)