### PR TITLE
Use current HHVM rather than an EOL version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
     - COMPOSER_FLAGS=""
 
 matrix:
+  fast_finish: true
   include:
     - php: 5.3
     - php: 5.3
@@ -19,6 +20,9 @@ matrix:
     - php: 7.0
     - php: 7.1
     - php: hhvm
+      sudo: true
+      dist: trusty
+      group: edge # Until the next major stable image update
   allow_failures:
     - php: hhvm
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
-
 sudo: false
+dist: trusty
 
 env:
   global:
@@ -11,7 +11,9 @@ matrix:
   fast_finish: true
   include:
     - php: 5.3
+      dist: precise
     - php: 5.3
+      dist: precise
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 5.4
     - php: 5.5
@@ -20,9 +22,6 @@ matrix:
     - php: 7.0
     - php: 7.1
     - php: hhvm
-      sudo: true
-      dist: trusty
-      group: edge # Until the next major stable image update
   allow_failures:
     - php: hhvm
 


### PR DESCRIPTION
Pull Request for Issue we were testing against EOL hhvm 3.6.6

### Summary of Changes
This provides the current HHVM version (3.15.3 as of this PR) and will track with each release (i.e. will be 3.16 when 3.16 is released).

If testing against HHVM LST versions is desired follow this guide. https://docs.travis-ci.com/user/languages/php#HHVM-versions

Should be able to change HHVM to container based Trusty after Q1-17 https://blog.travis-ci.com/2016-11-08-trusty-container-public-beta/

### Testing Instructions
Merge by code review

### Documentation Changes Required
none