### PR TITLE
Change expiration unit

### DIFF
--- a/src/SessionInterface.php
+++ b/src/SessionInterface.php
@@ -16,9 +16,9 @@ namespace Joomla\Session;
 interface SessionInterface extends \IteratorAggregate
 {
 	/**
-	 * Get expiration time in minutes
+	 * Get expiration time in seconds
 	 *
-	 * @return  integer  The session expiration time in minutes
+	 * @return  integer  The session expiration time in seconds
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */


### PR DESCRIPTION
Summary of Changes

The Session Interface has a wrong session expiration unit. Expiration/life time should be in seconds instead of minutes.

see https://github.com/joomla-framework/session/blob/2.0-dev/src/Session.php#L43
https://github.com/joomla/joomla-cms/pull/15120