### PR TITLE
Move MockStorage to main library as a documented feature for CLI Apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor/
 composer.phar
 composer.lock
 phpunit.xml
+.idea/

--- a/docs/v1-to-v2-update.md
+++ b/docs/v1-to-v2-update.md
@@ -29,9 +29,12 @@ was handling.
 ### Joomla\Session\StorageInterface added
 
 A new interface, [Joomla\Session\StorageInterface](classes/StorageInterface.md), has been added to represent a class acting as
-a session store. A default implementation, `Joomla\Session\Storage\NativeStorage`, is included which stores data to PHP's `$_SESSION`
-superglobal. Abstracting this logic to a new interface improves the internal architecture of the package and enables better testing
-of the API.
+a session store. Abstracting this logic to a new interface improves the internal architecture of the package and enables better
+testing of the API. There are two default implementations:
+
+1) `Joomla\Session\Storage\NativeStorage`, which stores data to PHP's `$_SESSION` superglobal.
+2) `Joomla\Session\Storage\RuntimeStorage` which stores data in PHP's memory. This is useful for when running unit tests,
+or conventional CLI Applications.
 
 ### Joomla\Session\Session::getInstance() removed
 

--- a/src/Storage/RuntimeStorage.php
+++ b/src/Storage/RuntimeStorage.php
@@ -4,14 +4,17 @@
  * @license    GNU General Public License version 2 or later; see LICENSE
  */
 
-namespace Joomla\Session\Tests\Storage;
+namespace Joomla\Session\Storage;
 
 use Joomla\Session\StorageInterface;
 
 /**
- * Mock session storage object for testing
+ * Session storage object that stores objects in Runtime memory. This is designed for use in CLI Apps, including
+ * unit testing applications in PHPUnit.
+ *
+ * @since  __DEPLOY_VERSION__
  */
-class MockStorage implements StorageInterface
+class RuntimeStorage implements StorageInterface
 {
 	/**
 	 * Flag if the session is active
@@ -294,7 +297,7 @@ class MockStorage implements StorageInterface
 	{
 		if ($this->isStarted())
 		{
-			return true;
+			return;
 		}
 
 		if ($this->isActive())

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -7,7 +7,7 @@
 namespace Joomla\Session\Tests;
 
 use Joomla\Session\Session;
-use Joomla\Session\Tests\Storage\MockStorage;
+use Joomla\Session\Storage\RuntimeStorage;
 use Joomla\Session\Validator\AddressValidator;
 use Joomla\Session\Validator\ForwardedValidator;
 use Joomla\Test\TestHelper;
@@ -27,7 +27,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 	/**
 	 * Storage object for testing
 	 *
-	 * @var  MockStorage
+	 * @var  RuntimeStorage
 	 */
 	private $storage;
 
@@ -46,7 +46,7 @@ class SessionTest extends \PHPUnit_Framework_TestCase
 
 		TestHelper::setValue($mockInput, 'inputs', $inputInternals);
 
-		$this->storage = new MockStorage;
+		$this->storage = new RuntimeStorage;
 		$this->session = new Session($this->storage);
 		$addressValidator = new AddressValidator($mockInput, $this->session);
 		$forwardedValidator = new ForwardedValidator($mockInput, $this->session);


### PR DESCRIPTION
### Summary of Changes
Moves the MockStorage to a documented RuntimeStorage class for use in CLI Apps

I've also fixed a bug where the `start()` function in the driver would return `true` instead of the documented `void`

### Testing Instructions
Use it in CLI Apps

### Documentation Changes Required
Documented in PR
