### PR TITLE
fix double login if session expired

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -599,13 +599,13 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	 */
 	public function fork($destroy = false)
 	{
+                $this->store->regenerate($destroy);
+
 		if ($this->getState() !== 'active')
 		{
 			// @TODO :: generated error here
 			return false;
 		}
-
-		$this->store->regenerate($destroy);
 
 		if ($destroy)
 		{

--- a/src/Session.php
+++ b/src/Session.php
@@ -599,13 +599,8 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	 */
 	public function fork($destroy = false)
 	{
-                $this->store->regenerate($destroy);
 
-		if ($this->getState() !== 'active')
-		{
-			// @TODO :: generated error here
-			return false;
-		}
+                $this->store->regenerate($destroy);
 
 		if ($destroy)
 		{


### PR DESCRIPTION
Pull Request for [Issue](https://github.com/joomla/joomla-cms/issues/19769).

### Summary of Changes

A new session needs to be generated even when the last one is expired. This fix solves the problem, but I there may be a better way to do it, by changing the flow entirely when the session is expired.

The basic issue was that after a refresh of Joomla with an expired session, a new one is not generated at first, but only after the user tries to login once.

### Testing Instructions

Change this [line](https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/vendor/joomla/session/src/Session.php#L710) for faster expiration time.

`$this->expire = 10;`

In order to reproduce the bug:

1. log in to admin and wait until the session expires;

2. wait until session expires and refresh the page;

3. enter login credentials and submit form, the page will be reloaded with the error message.


### Result

The login process works flawlessly after the session is expired.
