### PR TITLE
Fixes open_basedir issue (Issue #20821) in Joomla! 4 Alpha

### DIFF
--- a/src/Handler/FilesystemHandler.php
+++ b/src/Handler/FilesystemHandler.php
@@ -28,12 +28,23 @@ class FilesystemHandler extends \SessionHandler implements HandlerInterface
 	 */
 	public function __construct(string $path = '')
 	{
-		$path = $path ?: ini_get('session.save_path');
+		$pathConfig = ini_get('session.save_path');
 
-		// If the path is still empty, then we can't use this handler
-		if (empty($path))
+		// If the paths are empty, then we can't use this handler
+		if (empty($path) && empty($pathConfig))
 		{
 			throw new \InvalidArgumentException('Invalid argument $path');
+		}
+
+		// If path is empty or equal to the the PHP configured path, set only the handler and use the PHP path directly
+		if (empty($path) || $path === $pathConfig)
+		{
+			if (!headers_sent())
+			{
+				ini_set('session.save_handler', 'files');
+			}
+
+			return;
 		}
 
 		$baseDir = $path;


### PR DESCRIPTION
Pull Request for Issue #20821

### Summary of Changes

If the PHP configured session path is used, then we don't need to check whether we can create a folder in this path. This will throw an error on most servers (at least on servers that are correctly configured).

### Testing Instructions

Set the open_basedir value to the document root (or web space root) only and try to install the latest Alpha package. Without the patch, you will get the error described in this comment (https://github.com/joomla/joomla-cms/issues/20821#issuecomment-405216900). After you've applied the patch, everything will work as expected, and the installation form will be loaded.

### Documentation Changes Required

No.