### PR TITLE
[2.0] Remove Session::getHandlers()

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -233,50 +233,6 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	}
 
 	/**
-	 * Get the available session handlers
-	 *
-	 * @return  array  An array of available session handlers
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public static function getHandlers(): array
-	{
-		$connectors = [];
-
-		// Get an iterator and loop trough the handler classes.
-		$iterator = new \DirectoryIterator(__DIR__ . '/Handler');
-
-		foreach ($iterator as $file)
-		{
-			$fileName = $file->getFilename();
-
-			// Only load for PHP files.
-			if (!$file->isFile() || $file->getExtension() != 'php')
-			{
-				continue;
-			}
-
-			// Derive the class name from the type.
-			$class = str_ireplace('.php', '', __NAMESPACE__ . '\\Handler\\' . ucfirst(trim($fileName)));
-
-			// If the class doesn't exist we have nothing left to do but look at the next type. We did our best.
-			if (!class_exists($class))
-			{
-				continue;
-			}
-
-			// Sweet!  Our class exists, so now we just need to know if it passes its test method.
-			if ($class::isSupported())
-			{
-				// Connector names should not have file the handler suffix or the file extension.
-				$connectors[] = str_ireplace('Handler.php', '', $fileName);
-			}
-		}
-
-		return $connectors;
-	}
-
-	/**
 	 * Check if the session is active
 	 *
 	 * @return  boolean

--- a/tests/SessionTest.php
+++ b/tests/SessionTest.php
@@ -188,15 +188,6 @@ class SessionTest extends TestCase
 	}
 
 	/**
-	 * @covers  Joomla\Session\Session::getHandlers()
-	 */
-	public function testValidateAListOfAvailableHandlersIsReturned()
-	{
-		// There should be at least one handler available in our test environment
-		$this->assertGreaterThan(0, Session::getHandlers());
-	}
-
-	/**
 	 * @covers  Joomla\Session\Session::getIterator()
 	 */
 	public function testValidateAnIteratorIsReturned()


### PR DESCRIPTION
### Summary of Changes

The `Joomla\Session\Session::getHandlers()` method is removed.  The long and short is the method here doesn't really allow integration of external handlers and its only use is to support `Joomla\CMS\Form\Field\SessionhandlerField`, so I think we're better off removing the method from the Framework and the CMS can either add it to its Session subclass or just inline the logic into the form field.  The other option if it's decided the framework should have this kind of logic is to create a `SessionHandlerRegistry` that holds the known handlers (and inherently allows a downstream application to add, replace, and remove options as desired).

### Documentation Changes Required

N/A, from a Framework perspective this replaces `Joomla\Session\Session::getStores()` which was deprecated in 1.x and removed in 2.0 since much of the API logic was restructured.