### PR TITLE
Dont close on session destroy

### DIFF
--- a/src/Handler/RedisHandler.php
+++ b/src/Handler/RedisHandler.php
@@ -69,8 +69,6 @@ class RedisHandler implements HandlerInterface
 	 */
 	public function close()
 	{
-		$this->redis->close();
-
 		return true;
 	}
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/30377 (and its duplicate at joomla/joomla-cms#33704 which describes the issues better) 

### Summary of Changes

On a session destroy (with session_regenerate_id()) dont close the connection to redis in the handler. 

### Testing Instructions

https://github.com/joomla/joomla-cms/issues/33704

### Documentation Changes Required

none