### PR TITLE
correctly not close connection to redis on destroying session

### DIFF
--- a/src/Handler/ApcuHandler.php
+++ b/src/Handler/ApcuHandler.php
@@ -59,7 +59,7 @@ class ApcuHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
-	public function destroy($session_id)
+	public function destroy($session_id): bool
 	{
 		// The apcu_delete function returns false if the id does not exist
 		return apcu_delete($this->prefix . $session_id) || !apcu_exists($this->prefix . $session_id);

--- a/src/Handler/DatabaseHandler.php
+++ b/src/Handler/DatabaseHandler.php
@@ -166,7 +166,7 @@ class DatabaseHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
-	public function destroy($session_id)
+	public function destroy($session_id): bool
 	{
 		try
 		{

--- a/src/Handler/MemcachedHandler.php
+++ b/src/Handler/MemcachedHandler.php
@@ -81,7 +81,7 @@ class MemcachedHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
-	public function destroy($session_id)
+	public function destroy($session_id): bool
 	{
 		return $this->memcached->delete($this->prefix . $session_id);
 	}

--- a/src/Handler/RedisHandler.php
+++ b/src/Handler/RedisHandler.php
@@ -69,13 +69,12 @@ class RedisHandler implements HandlerInterface
 	 */
 	public function close()
 	{
-		$this->redis->close();
-
+		// No need to close the connection to Redis server manually.
 		return true;
 	}
 
 	/**
-	 * Destroy a session
+	 * Destroy a session, called automatically when running session_regenerate_id().
 	 *
 	 * @param   integer  $session_id  The session ID being destroyed
 	 *
@@ -83,11 +82,12 @@ class RedisHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
-	public function destroy($session_id)
+	public function destroy($session_id): bool
 	{
 		$this->redis->del($this->prefix . $session_id);
 
-		return $this->close();
+		// Session callback must have a return value of type bool when session_regenerate_id() is called.
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/30377 (and its duplicate at joomla/joomla-cms#33704 which describes the issues better) 

### Summary of Changes

On a session destroy (with session_regenerate_id()) dont close the connection to redis in the handler. 

This PR allows login and logout without any errors

### Testing Instructions

https://github.com/joomla/joomla-cms/issues/33704

### Documentation Changes Required

none

//cc @alikon @wilsonge 