### PR TITLE
use joomla-framwork/utilities IpHelper to detect client IP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "joomla/coding-standards": "^3.0@dev",
         "joomla/console": "^2.0",
         "joomla/database": "^2.0",
+        "joomla/utilities": "^2.0",
         "joomla/event": "^2.0",
         "joomla/input": "^2.0",
         "joomla/test": "^2.0",

--- a/src/Validator/AddressValidator.php
+++ b/src/Validator/AddressValidator.php
@@ -12,6 +12,7 @@ use Joomla\Input\Input;
 use Joomla\Session\Exception\InvalidSessionException;
 use Joomla\Session\SessionInterface;
 use Joomla\Session\ValidatorInterface;
+use Joomla\Utilities\IpHelper;
 
 /**
  * Interface for validating a part of the session
@@ -67,7 +68,7 @@ class AddressValidator implements ValidatorInterface
 			$this->session->set('session.client.address', null);
 		}
 
-		$remoteAddr = $this->input->server->getString('REMOTE_ADDR', '');
+		$remoteAddr = IpHelper::getIp();
 
 		// Check for client address
 		if (!empty($remoteAddr) && filter_var($remoteAddr, FILTER_VALIDATE_IP) !== false)


### PR DESCRIPTION
Possible solution for https://github.com/joomla-framework/session/issues/54 and thus https://github.com/joomla/joomla-cms/issues/35244 that fixes https://github.com/joomla/joomla-cms/issues/35244#issuecomment-915160910 CloudFlare (and other reverse proxy's that set REMOTE_ADDR as their IP and not the clients IP (which is perfectly valid for a proxy to do that, but causes session logout issues as REMOTE_ADDR frequently changes. 

Joomla 4 is effected by this 

@nibra @wilsonge 

This also now leaves the `$input` in the constructor redundant, and can be deprecated out of the class sometime before Joomla 999