### PR TITLE
PHP 8.1 deprecation notices.

### DIFF
--- a/src/Handler/ApcuHandler.php
+++ b/src/Handler/ApcuHandler.php
@@ -45,6 +45,7 @@ class ApcuHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function close()
 	{
 		return true;
@@ -74,6 +75,7 @@ class ApcuHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function gc($maxlifetime)
 	{
 		return true;
@@ -109,6 +111,7 @@ class ApcuHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function open($save_path, $session_id)
 	{
 		return true;
@@ -123,6 +126,7 @@ class ApcuHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function read($session_id)
 	{
 		return (string) apcu_fetch($this->prefix . $session_id);
@@ -138,6 +142,7 @@ class ApcuHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function write($session_id, $session_data)
 	{
 		return apcu_store($this->prefix . $session_id, $session_data, ini_get('session.gc_maxlifetime'));

--- a/src/Handler/DatabaseHandler.php
+++ b/src/Handler/DatabaseHandler.php
@@ -66,6 +66,7 @@ class DatabaseHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function close()
 	{
 		if ($this->gcCalled)
@@ -194,6 +195,7 @@ class DatabaseHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function gc($maxlifetime)
 	{
 		// We'll delay garbage collection until the session is closed to prevent potential issues mid-cycle
@@ -225,6 +227,7 @@ class DatabaseHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function open($save_path, $session_id)
 	{
 		$this->db->connect();
@@ -241,6 +244,7 @@ class DatabaseHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function read($session_id)
 	{
 		try
@@ -272,6 +276,7 @@ class DatabaseHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function write($session_id, $session_data)
 	{
 		try

--- a/src/Handler/MemcachedHandler.php
+++ b/src/Handler/MemcachedHandler.php
@@ -67,6 +67,7 @@ class MemcachedHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function close()
 	{
 		return true;
@@ -95,6 +96,7 @@ class MemcachedHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function gc($maxlifetime)
 	{
 		// Memcached manages garbage collection on its own
@@ -127,6 +129,7 @@ class MemcachedHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function open($save_path, $session_id)
 	{
 		return true;
@@ -141,6 +144,7 @@ class MemcachedHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function read($session_id)
 	{
 		return $this->memcached->get($this->prefix . $session_id) ?: '';
@@ -156,6 +160,7 @@ class MemcachedHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function write($session_id, $session_data)
 	{
 		return $this->memcached->set($this->prefix . $session_id, $session_data, time() + $this->ttl);

--- a/src/Handler/RedisHandler.php
+++ b/src/Handler/RedisHandler.php
@@ -67,6 +67,7 @@ class RedisHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function close()
 	{
 		// No need to close the connection to Redis server manually.
@@ -99,6 +100,7 @@ class RedisHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function gc($maxlifetime)
 	{
 		return true;
@@ -126,6 +128,7 @@ class RedisHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function open($save_path, $session_id)
 	{
 		return true;
@@ -140,6 +143,7 @@ class RedisHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function read($session_id)
 	{
 		return $this->redis->get($this->prefix . $session_id) ?: '';
@@ -155,6 +159,7 @@ class RedisHandler implements HandlerInterface
 	 *
 	 * @since   2.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function write($session_id, $session_data)
 	{
 		if ($this->ttl > 0)

--- a/src/Session.php
+++ b/src/Session.php
@@ -172,6 +172,7 @@ class Session implements SessionInterface, DispatcherAwareInterface
 	 *
 	 * @since   1.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator()
 	{
 		return new \ArrayIterator($this->all());


### PR DESCRIPTION
Pull Request for Issue #

### Summary of Changes
Silencing PHP 8.1 deprecation notices that prevents Joomla! from running with error reporting on.
Example of error message:
 PHP Deprecated:  Return type of Joomla\Session\Handler\RedisHandler::open($save_path, $session_id) should either be compatible with SessionHandlerInterface::open(string $path, string $name): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in D:\virtualhosts\clean40\libraries\vendor\joomla\session\src\Handler\RedisHandler.php on line 129

Snip from PHP.net Backward Incompatible Changes:

![image](https://user-images.githubusercontent.com/25645600/145477202-6c44b217-b8ae-4aa3-9393-3fb5ea070322.png)

### Testing Instructions
Code review or check that errors disappear from logfile.
### Documentation Changes Required
Probably not.