### PR TITLE
[PHP8.4] Deprecate implicitly nullable parameter types

### DIFF
--- a/src/Session.php
+++ b/src/Session.php
@@ -60,16 +60,16 @@ class Session implements SessionInterface, DispatcherAwareInterface
     /**
      * Constructor
      *
-     * @param   StorageInterface     $store       A StorageInterface implementation.
-     * @param   DispatcherInterface  $dispatcher  DispatcherInterface for the session to use.
-     * @param   array                $options     Optional parameters. Supported keys include:
-     *                                            - name: The session name
-     *                                            - id: The session ID
-     *                                            - expire: The session lifetime in seconds
+     * @param   ?StorageInterface     $store       A StorageInterface implementation.
+     * @param   ?DispatcherInterface  $dispatcher  DispatcherInterface for the session to use.
+     * @param   array                 $options     Optional parameters. Supported keys include:
+     *                                             - name: The session name
+     *                                             - id: The session ID
+     *                                             - expire: The session lifetime in seconds
      *
      * @since   1.0
      */
-    public function __construct(StorageInterface $store = null, DispatcherInterface $dispatcher = null, array $options = [])
+    public function __construct(?StorageInterface $store = null, ?DispatcherInterface $dispatcher = null, array $options = [])
     {
         $this->store = $store ?: new Storage\NativeStorage(new Handler\FilesystemHandler());
 

--- a/src/Storage/NativeStorage.php
+++ b/src/Storage/NativeStorage.php
@@ -54,8 +54,8 @@ class NativeStorage implements StorageInterface
     /**
      * Constructor
      *
-     * @param   \SessionHandlerInterface  $handler  Session save handler
-     * @param   array                     $options  Session options
+     * @param   ?\SessionHandlerInterface  $handler  Session save handler
+     * @param   array                      $options  Session options
      *
      * @since   1.0
      */
@@ -322,7 +322,7 @@ class NativeStorage implements StorageInterface
     /**
      * Registers session save handler as a PHP session handler
      *
-     * @param   \SessionHandlerInterface  $handler  The save handler to use
+     * @param   ?\SessionHandlerInterface  $handler  The save handler to use
      *
      * @return  $this
      *

--- a/tests/Handler/DatabaseHandlerTest.php
+++ b/tests/Handler/DatabaseHandlerTest.php
@@ -7,7 +7,6 @@
 
 namespace Joomla\Session\Tests\Handler;
 
-use Joomla\Database\DatabaseDriver;
 use Joomla\Database\Sqlite\SqliteDriver;
 use Joomla\Session\Handler\DatabaseHandler;
 use Joomla\Session\Tests\DatabaseManager;


### PR DESCRIPTION
### Summary of Changes

updates for [Deprecate implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

### Testing Instructions

code review

### Documentation Changes Required

no